### PR TITLE
feat: support local registration

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,5 +41,6 @@
       "last 1 firefox version",
       "last 1 safari version"
     ]
-  }
+  },
+  "proxy": "http://localhost:5001"
 }

--- a/src/Register.js
+++ b/src/Register.js
@@ -21,10 +21,8 @@ const Register = () => {
   const handleSubmit = async (e) => {
     e.preventDefault();
     try {
-      const response = await axios.post(
-        "https://server-registration-app.phoubon.in.th/register",
-        formData
-      );
+      // ส่งคำขอลงทะเบียนไปยังเซิร์ฟเวอร์ภายในแอปเอง
+      const response = await axios.post("/register", formData);
       alert(response?.data?.message);
     } catch (error) {
       console.error(error);

--- a/src/server.js
+++ b/src/server.js
@@ -4,9 +4,11 @@ const bodyParser = require("body-parser");
 const cors = require("cors");
 const bcrypt = require('bcryptjs');
 
-const app = express();
-app.use(cors());
-app.use(bodyParser.json());
+// สร้างฟังก์ชันสำหรับเริ่มต้นเซิร์ฟเวอร์ Express
+function createServer() {
+  const app = express();
+  app.use(cors());
+  app.use(bodyParser.json());
 
 const db = mysql.createPool({
   connectionLimit: 10,
@@ -91,7 +93,7 @@ const db4 = mysql.createConnection({
 //   console.log("เชื่อมต่อกับฐานข้อมูลสำเร็จ");
 // });
 
-app.get("/person",async (req, res) => {
+  app.get("/person",async (req, res) => {
 try {
   // Query data from MySQL
   const [results] = await db.query("SELECT * FROM users WHERE first_name = 'suphot' limit 10");
@@ -106,9 +108,9 @@ try {
     message: "Something went wrong.",
   });
 }
-});
+  });
 
-app.post("/register", async (req, res) => {
+  app.post("/register", async (req, res) => {
   const { firstName, lastName, idNumber, phone, password } = req.body;
   console.log("======>",{...req.body});
 
@@ -138,10 +140,10 @@ app.post("/register", async (req, res) => {
     console.error("เกิดข้อผิดพลาด:", err);
     res.status(500).send({ message: "เกิดข้อผิดพลาดในการลงทะเบียน" });
   }
-});
+  });
 
 
-app.post("/login",async (req, res) => {
+  app.post("/login",async (req, res) => {
   const { idNumber, password } = req.body;
   console.log("======>",{...req.body});
 
@@ -205,8 +207,17 @@ chospcode.hospname
     console.error("เกิดข้อผิดพลาด:", err);
     res.status(500).send({ message: "เกิดข้อผิดพลาดในการดึงข้อมูลการตรวจเลือด" });
   }
-});
+  });
 
-app.listen(5001, () => {
-  console.log("เซิร์ฟเวอร์กำลังทำงานที่พอร์ต 5001");
-});
+  return app;
+}
+
+// หากไฟล์นี้ถูกเรียกโดยตรง ให้เริ่มเซิร์ฟเวอร์ทันที
+if (require.main === module) {
+  const app = createServer();
+  app.listen(5001, () => {
+    console.log("เซิร์ฟเวอร์กำลังทำงานที่พอร์ต 5001");
+  });
+}
+
+module.exports = createServer;


### PR DESCRIPTION
## Summary
- allow registration form to post to internal server instead of external service
- expose express app as a reusable function so it can run within the project
- configure React proxy to forward local API calls to the backend

## Testing
- `CI=true npm test -- --passWithNoTests`

------
https://chatgpt.com/codex/tasks/task_e_689f8ced4eb083289af0c2d49cb73a39