### PR TITLE
Serve app on single port 3000

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "web-vitals": "^2.1.4"
   },
   "scripts": {
-    "start": "react-scripts start",
+    "start": "npm run build && node src/server.js",
     "build": "react-scripts build",
     "test": "react-scripts test",
     "eject": "react-scripts eject"
@@ -43,6 +43,5 @@
       "last 1 firefox version",
       "last 1 safari version"
     ]
-  },
-  "proxy": "http://localhost:5001"
+  }
 }

--- a/src/server.js
+++ b/src/server.js
@@ -9,8 +9,10 @@ const bcrypt = require("bcryptjs");
 const cors = require("cors");
 const bodyParser = require("body-parser");
 const mysql = require("mysql2/promise");
+const path = require("path");
 
-const PORT = process.env.PORT || 5001;
+// Single-service port: default to 3000
+const PORT = process.env.PORT || 3000;
 
 // --- DB CONNECTIONS ---------------------------------------------------------
 // Primary DB (users)
@@ -57,10 +59,7 @@ chospcode.hospname
 const app = express();
 app.use(cors());
 app.use(bodyParser.json());
-
-app.get("/", (_req, res) => {
-  res.send({ ok: true, message: "API is running" });
-});
+app.use(express.static(path.join(__dirname, "../build")));
 
 // --- REGISTER ---------------------------------------------------------------
 app.post("/register", async (req, res) => {
@@ -165,6 +164,11 @@ app.get("/labs/:idNumber", async (req, res) => {
     console.error("LABS ERROR:", err);
     res.status(500).send({ success: false, message: "เกิดข้อผิดพลาดในการดึงข้อมูลแลบ" });
   }
+});
+
+// Serve React app for any other route
+app.get("*", (_req, res) => {
+  res.sendFile(path.join(__dirname, "../build/index.html"));
 });
 
 // --- START ------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Run Express server and React build on a single port 3000
- Replace start script with build step followed by server launch for one-command startup

## Testing
- `npm test -- --watchAll=false --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_689fa80b0d108328b9c25199e4545de1