### PR TITLE
Change default server port to 3088

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ In the project directory, you can run:
 ### `npm start`
 
 Runs the app in the development mode.\
-Open [http://localhost:3000](http://localhost:3000) to view it in your browser.
+Open [http://localhost:3088](http://localhost:3088) to view it in your browser.
 
 The page will reload when you make changes.\
 You may also see any lint errors in the console.

--- a/src/server.js
+++ b/src/server.js
@@ -11,8 +11,8 @@ const bodyParser = require("body-parser");
 const mysql = require("mysql2/promise");
 const path = require("path");
 
-// Single-service port: default to 3000
-const PORT = process.env.PORT || 3000;
+// Single-service port: default to 3088
+const PORT = process.env.PORT || 3088;
 
 // --- DB CONNECTIONS ---------------------------------------------------------
 // Primary DB (users)


### PR DESCRIPTION
## Summary
- default Express server to port 3088
- update documentation to reference port 3088

## Testing
- `npm test -- --watchAll=false --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_689fd763c6dc83288821f29e08dd79b8